### PR TITLE
Add support for joint_position

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@
 [![Build Status][travis-status]][travis]
 
 See the [Franka Control Interface (FCI) documentation][fci-docs] for more information.
+## About this fork
+
+This fork adds a ROS node which can be launched with
+```
+roslaunch ros_subscriber_controller.launch
+```
+The node will subscribe to  **controller_command/joint_command** which is sensor message of type JointState.
+
+In this message either the joint velocities or joint positions can be specified. The joint position is prioritized higher, in order to provide a joint velocity **set all joint positions to zero**.
 
 ## License
 

--- a/franka_example_controllers/include/franka_example_controllers/ros_subscriber_controller.h
+++ b/franka_example_controllers/include/franka_example_controllers/ros_subscriber_controller.h
@@ -25,11 +25,13 @@ class RosSubscriberController : public controller_interface::MultiInterfaceContr
   void stopping(const ros::Time&) override;
 
  private:
-  void joint_velocity_callback (const sensor_msgs::JointState joint_velocity);
+  void joint_state_callback (const sensor_msgs::JointState joint_command);
   hardware_interface::VelocityJointInterface* velocity_joint_interface_;
+  hardware_interface::PositionJointInterface* position_joint_interface_;
   std::vector<hardware_interface::JointHandle> velocity_joint_handles_;
-  ros::Subscriber joint_velocity_subscriber_;
-  sensor_msgs::JointState velocity_setpoint_;
+  std::vector<hardware_interface::JointHandle> position_joint_handles_;
+  ros::Subscriber joint_command_subscriber_;
+  sensor_msgs::JointState joint_command_;
 };
 
 }  // namespace franka_example_controllers

--- a/franka_example_controllers/src/ros_subscriber_controller.cpp
+++ b/franka_example_controllers/src/ros_subscriber_controller.cpp
@@ -14,51 +14,63 @@ namespace franka_example_controllers {
 
 bool RosSubscriberController::init(hardware_interface::RobotHW* robot_hardware,
                                           ros::NodeHandle& node_handle) {
-  velocity_setpoint_.velocity.resize(7);
-  for (size_t i = 0; i < 7; ++i) {
-    velocity_setpoint_.velocity.at(i) = 0.0f;
-  }
+
   velocity_joint_interface_ = robot_hardware->get<hardware_interface::VelocityJointInterface>();
+
   if (velocity_joint_interface_ == nullptr) {
     ROS_ERROR(
         "RosSubscriberController: Error getting velocity joint interface from hardware!");
     return false;
   }
+
+  position_joint_interface_ = robot_hardware->get<hardware_interface::PositionJointInterface>();
+  if (position_joint_interface_ == nullptr) {
+    ROS_ERROR(
+            "JointPositionExampleController: Error getting position joint interface from hardware!");
+    return false;
+  }
+
   std::vector<std::string> joint_names;
   if (!node_handle.getParam("joint_names", joint_names)) {
     ROS_ERROR("RosSubscriberController: Could not parse joint names");
   }
+
   if (joint_names.size() != 7) {
     ROS_ERROR_STREAM("RosSubscriberController: Wrong number of joint names, got "
                      << joint_names.size() << " instead of 7 names!");
     return false;
   }
+
   velocity_joint_handles_.resize(7);
   for (size_t i = 0; i < 7; ++i) {
     try {
       velocity_joint_handles_[i] = velocity_joint_interface_->getHandle(joint_names[i]);
-    } catch (const hardware_interface::HardwareInterfaceException& ex) {
+    } catch (const hardware_interface::HardwareInterfaceException &ex) {
       ROS_ERROR_STREAM(
-          "RosSubscriberController: Exception getting joint handles: " << ex.what());
+              "RosSubscriberController: Exception getting joint handles: " << ex.what());
       return false;
     }
-    joint_velocity_subscriber_ = node_handle.subscribe ("controller_command/joint_velocity",
-            10, &RosSubscriberController::joint_velocity_callback, this);
   }
 
-  auto state_interface = robot_hardware->get<franka_hw::FrankaStateInterface>();
-  if (state_interface == nullptr) {
-    ROS_ERROR("RosSubscriberController: Could not get state interface from hardware");
-    return false;
-  }
+    position_joint_handles_.resize(7);
+    for (size_t i = 0; i < 7; ++i) {
+      try {
+        position_joint_handles_[i] = position_joint_interface_->getHandle(joint_names[i]);
+      } catch (const hardware_interface::HardwareInterfaceException &e) {
+        ROS_ERROR_STREAM(
+                "JointPositionExampleController: Exception getting joint handles: " << e.what());
+        return false;
+      }
+    }
 
-  try {
-    auto state_handle = state_interface->getHandle("panda_robot");
-  } catch (const hardware_interface::HardwareInterfaceException& e) {
-    ROS_ERROR_STREAM(
-        "RosSubscriberController: Exception getting state handle: " << e.what());
-    return false;
-  }
+      joint_command_.velocity.resize(7);
+      for (size_t i = 0; i < 7; ++i) {
+        joint_command_.velocity.at(i) = 0.0f;
+        joint_command_.position.at(i) = position_joint_handles_[i].getPosition();
+      }
+
+      joint_command_subscriber_ = node_handle.subscribe ("controller_command/joint_command",
+            10, &RosSubscriberController::joint_state_callback, this);
 
   return true;
 }
@@ -68,14 +80,31 @@ void RosSubscriberController::starting(const ros::Time& /* time */) {
 
 void RosSubscriberController::update(const ros::Time& /* time */,
                                             const ros::Duration& period) {
-  if (velocity_setpoint_.velocity.size() != 7) {
-    ROS_ERROR_STREAM(
-            "RosSubscriberController: Was expecting 7 values for the joints. ");
+  float velocity_speed_sum = 0.0f;
+  for (size_t i = 0; i < 7; ++i) {
+    velocity_speed_sum += joint_command_.velocity.at(i);
+  }
+
+  if (velocity_speed_sum != 0.0f) {
+    if (joint_command_.velocity.size() != 7) {
+      ROS_ERROR_STREAM(
+              "RosSubscriberController: Was expecting 7 values for the joint velocity. ");
+    } else {
+      for (size_t i = 0; i < 7; ++i) {
+        velocity_joint_handles_.at(i).setCommand(joint_command_.velocity.at(i));
+      }
+    }
   } else {
-    for (size_t i = 0; i < 7; ++i) {
-      velocity_joint_handles_.at(i).setCommand(velocity_setpoint_.velocity.at(i));
+    if (joint_command_.position.size() != 7) {
+      ROS_ERROR_STREAM(
+              "RosSubscriberController: Was expecting 7 values for the joint position. ");
+    } else {
+      for (size_t i = 0; i < 7; ++i) {
+        position_joint_handles_.at(i).setCommand(joint_command_.position.at(i));
+      }
     }
   }
+
 }
 
 void RosSubscriberController::stopping(const ros::Time& /*time*/) {
@@ -84,8 +113,8 @@ void RosSubscriberController::stopping(const ros::Time& /*time*/) {
   // BUILT-IN STOPPING BEHAVIOR SLOW DOWN THE ROBOT.
 }
 
-void RosSubscriberController::joint_velocity_callback (const sensor_msgs::JointState joint_velocity) {
-  velocity_setpoint_ = joint_velocity;
+void RosSubscriberController::joint_state_callback (const sensor_msgs::JointState joint_command) {
+  joint_command_ = joint_command;
 }
 
 }  // namespace franka_example_controllers

--- a/franka_example_controllers/src/ros_subscriber_controller.cpp
+++ b/franka_example_controllers/src/ros_subscriber_controller.cpp
@@ -80,27 +80,30 @@ void RosSubscriberController::starting(const ros::Time& /* time */) {
 
 void RosSubscriberController::update(const ros::Time& /* time */,
                                             const ros::Duration& period) {
-  float velocity_speed_sum = 0.0f;
+  bool set_position = false;
   for (size_t i = 0; i < 7; ++i) {
-    velocity_speed_sum += joint_command_.velocity.at(i);
+    if (joint_command_.position.at(i) != 0.0f) {
+        set_position = true;
+        break;
+    }
   }
 
-  if (velocity_speed_sum != 0.0f) {
-    if (joint_command_.velocity.size() != 7) {
-      ROS_ERROR_STREAM(
-              "RosSubscriberController: Was expecting 7 values for the joint velocity. ");
-    } else {
-      for (size_t i = 0; i < 7; ++i) {
-        velocity_joint_handles_.at(i).setCommand(joint_command_.velocity.at(i));
-      }
-    }
-  } else {
+  if (set_position) {
     if (joint_command_.position.size() != 7) {
       ROS_ERROR_STREAM(
               "RosSubscriberController: Was expecting 7 values for the joint position. ");
     } else {
       for (size_t i = 0; i < 7; ++i) {
         position_joint_handles_.at(i).setCommand(joint_command_.position.at(i));
+      }
+    }
+  } else {
+    if (joint_command_.velocity.size() != 7) {
+      ROS_ERROR_STREAM(
+              "RosSubscriberController: Was expecting 7 values for the joint velocity. ");
+    } else {
+      for (size_t i = 0; i < 7; ++i) {
+        velocity_joint_handles_.at(i).setCommand(joint_command_.velocity.at(i));
       }
     }
   }


### PR DESCRIPTION
Users are now able to set joint positions! Positions are prioritized over the joint velocities. If you want to set velocities set all positions to zero.
NOTE: This also means that you can not set the 0,0,0,0,0,0,0 position.